### PR TITLE
Fix for projects that do not have Rails::Railtie

### DIFF
--- a/lib/schema_validations.rb
+++ b/lib/schema_validations.rb
@@ -3,7 +3,7 @@ require 'valuable'
 require 'schema_plus'
 require 'schema_validations/version'
 require 'schema_validations/active_record/validations'
-require 'schema_validations/railtie' if defined?(Rails)
+require 'schema_validations/railtie' if defined?(Rails::Railtie)
 
 module SchemaValidations
 


### PR DESCRIPTION
schema_validations.rb:6
require 'schema_validations/railtie' if defined?(Rails)

Rails is defined for me, Rails::Railtie -- not.
Perhaps it is better to compare Rails.version or check if Rails::Railtie is defined?

=> Rails 2.3.17 application starting on http://0.0.0.0:3000
/Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:466:in load_missing_constant': uninitialized constant Rails::Railtie (NameError)
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:106:inrake_original_const_missing'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/rake-0.9.6/lib/rake/ext/module.rb:36:in const_missing'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/schema_validations-0.2.0/lib/schema_validations/railtie.rb:2
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:182:inrequire'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:182:in require'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:547:innew_constants_in'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:182:in require'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/schema_validations-0.2.0/lib/schema_validations.rb:6
from /Users/anton/.rvm/gems/ruby-1.8.7-p371@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:68:inrequire'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:68:in require'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:66:ineach'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:66:in require'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:55:ineach'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371@global/gems/bundler-1.2.3/lib/bundler/runtime.rb:55:in require'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371@global/gems/bundler-1.2.3/lib/bundler.rb:128:inrequire'
from ./script/../config/boot.rb:114:in load_gems'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/rails-2.3.17/lib/initializer.rb:164:inprocess'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/rails-2.3.17/lib/initializer.rb:113:in send'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/rails-2.3.17/lib/initializer.rb:113:inrun'
from /Users/anton/xf/idnet/config/environment.rb:27
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:182:in require'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:182:inrequire'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:547:in new_constants_in'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/activesupport-2.3.17/lib/active_support/dependencies.rb:182:inrequire'
from /Users/anton/.rvm/gems/ruby-1.8.7-p371/gems/rails-2.3.17/lib/commands/server.rb:84
from script/server:3:in `require'
from script/server:3
