### PR TITLE
Implement integral range deduction and validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ Constraints:
 
 Data types:
 
-|         Type       |                      Validation                           |
-|--------------------|-----------------------------------------------------------|
-| :boolean           | :validates ... :inclusion => { :in => [true, false] }     |
-| :float             | :validates ... :numericality => true                      |
-| :integer           | :validates ... :numericality => { :only_integer => true } |
+|         Type       |                      Validation                                                                                |
+|--------------------|----------------------------------------------------------------------------------------------------------------|
+| :boolean           | :validates ... :inclusion => { :in => [true, false] }                                                          |
+| :float             | :validates ... :numericality => true                                                                           |
+| :integer           | :validates ... :numericality => { :only_integer => true, :greater_than_or_equal_to => ..., :less_than => ... } |
 
 ## How do I know what it did?
 If you're curious (or dubious) about what validations SchemaValidations

--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -106,7 +106,7 @@ module SchemaValidations
 
           case datatype
           when :integer
-            validate_logged :validates_numericality_of, name, :allow_nil => true, :only_integer => true
+            load_integer_column_validations(name, column)
           when :numeric
             validate_logged :validates_numericality_of, name, :allow_nil => true
           when :text
@@ -125,6 +125,20 @@ module SchemaValidations
           # UNIQUE constraints
           add_uniqueness_validation(column) if column.unique?
         end
+      end
+
+      def load_integer_column_validations(name, column) # :nodoc:
+        options = { :allow_nil => true, :only_integer => true }
+
+        range = column.cast_type.send(:range)
+        options[:greater_than_or_equal_to] = range.begin
+        if range.exclude_end?
+          options[:less_than] = range.end
+        else
+          options[:less_than_or_equal_to] = range.end
+        end
+
+        validate_logged :validates_numericality_of, name, options
       end
 
       def load_association_validations #:nodoc:

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -66,6 +66,11 @@ describe "Validations" do
       expect(Article.new(:state => 1.23).error_on(:state).size).to eq(1)
     end
 
+    it "should validate the range of votes" do
+      expect(Article.new(votes: 2147483648).error_on(:votes).size).to eq(1)
+      expect(Article.new(votes: -2147483649).error_on(:votes).size).to eq(1)
+    end
+
     it "should validate average_mark numericality" do
       expect(Article.new(:average_mark => "high").error_on(:average_mark).size).to eq(1)
     end
@@ -315,6 +320,7 @@ describe "Validations" do
           t.string :title, :limit => 50
           t.text  :content, :null => false
           t.integer :state
+          t.integer :votes
           t.float   :average_mark, :null => false
           t.boolean :active, :null => false
         end


### PR DESCRIPTION
Tested with sqlite3 and postgresql.

This uses a protected method, #range, which is implemented in the sqlite3 and postgresql adapters. It seems that they extend an AR type, which calculates the maximum permissible range for a column (as `ActiveRecord::Type::Integer`). I cannot find any other way of accessing that information. Pointers welcome.

Addresses Coursemology/Coursemology2#353 also.