### PR TITLE
Do not allow composite uniqueness constraints to be triggered when the scope fields are nil.

### DIFF
--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -144,9 +144,14 @@ module SchemaValidations
 
       def add_uniqueness_validation(column) #:nodoc:
         scope = column.unique_scope.map(&:to_sym)
-        condition = :"#{column.name}_changed?"
         name = column.name.to_sym
-        validate_logged :validates_uniqueness_of, name, :scope => scope, :allow_nil => true, :if => condition
+        validate_logged :validates_uniqueness_of, name, :scope => scope, :allow_nil => true, :if => (proc do |record|
+          if scope.all? { |scope_sym| record.public_send(:"#{scope_sym}?") }
+            record.public_send(:"#{column.name}_changed?")
+          else
+            false
+          end
+        end)
       end
 
       def create_schema_validations? #:nodoc:

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -20,6 +20,11 @@ describe "Validations" do
           belongs_to :news_article, :class_name => 'Article', :foreign_key => :article_id
           schema_validations :except => :content
         end
+
+        class ArticleReview < ActiveRecord::Base
+          belongs_to :article
+          belongs_to :review
+        end
       end
     end
 
@@ -103,6 +108,19 @@ describe "Validations" do
       expect(Review.new.error_on(:news_article).size).to eq(1)
     end
 
+    it "should not validate uniqueness when scope is absent" do
+      article_review_1 = ArticleReview.create(:article_id => 1, :review_id => nil)
+      expect(article_review_1).to be_valid
+
+      article_review_2 = ArticleReview.create(:article_id => 1, :review_id => nil)
+      expect(article_review_2).to be_valid
+
+      article_review_3 = ArticleReview.create(:article_id => nil, :review_id => 1)
+      expect(article_review_3).to be_valid
+
+      article_review_4 = ArticleReview.create(:article_id => nil, :review_id => 1)
+      expect(article_review_4).to be_valid
+    end
   end
 
   context "auto-created but changed" do
@@ -311,6 +329,11 @@ describe "Validations" do
         end
         add_index :reviews, :article_id, :unique => true
 
+        create_table :article_reviews, :force => true do |t|
+          t.integer :article_id
+          t.integer :review_id
+        end
+        add_index :article_reviews, [:article_id, :review_id], :unique => true
       end
     end
   end


### PR DESCRIPTION
Fixes #23.