### PR TITLE
Changed log level to debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Data types:
 ## How do I know what it did?
 If you're curious (or dubious) about what validations SchemaValidations
 defines, you can check the log file.  For every assocation that
-SchemaValidations defines, it generates an info entry such as
+SchemaValidations defines, it generates an debug entry such as
 
     [schema_validations] Article.validates_length_of :title, :allow_nil=>true, :maximum=>50
 

--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -176,7 +176,7 @@ module SchemaValidations
         if _filter_validation(method, arg)
           msg = "[schema_validations] #{self.name}.#{method} #{arg.inspect}"
           msg += ", #{opts.inspect[1...-1]}" if opts.any?
-          logger.info msg
+          logger.debug msg
           send method, arg, opts
         end
       end


### PR DESCRIPTION
I would suggest that seeing what schema_validations does on each run is more
of a development debug notification rather than an info level. Especially if you
have a lot of processes starting and stopping this can be a lot of log lines for
a production server.