### PR TITLE
Preserve default options when merge with other custom options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ SchemaValidations::ActiveRecord::schema_validations, such as:
       schema_validations :except => :email
       validates :email, :presence => true, :length => { :in => 5..30 }
     end
+    
+There is also an whitelist option, by default `:created_at`, `:updated_at`, `:created_on`, `:updated_on` are whitelisted. You can also specify it and change this behaviour in your model.
+
+    class User < ActiveRecord::Base
+      schema_validations :whitelist => [] # In this case, every field will be validated.
+    end
 
 See SchemaValidations::Config for the available options.
 

--- a/lib/schema_validations.rb
+++ b/lib/schema_validations.rb
@@ -43,6 +43,21 @@ module SchemaValidations
     has_value :whitelist, :default => [:created_at, :updated_at, :created_on, :updated_on]
 
     ##
+    # :attr_accessor: except
+    #
+    # List of field names to exclude from automatic validation.
+    # Value is a single name, and array of names, or +nil+.  Default is +nil+.
+    has_value :except, :default => nil
+
+    ##
+    # :attr_accessor: whitelist_type
+    #
+    # List of validation types to exclude from automatic validation.
+    # Value is a single type, and array of types, or +nil+.  Default is +nil+.
+    # A type is specified as, e.g., +:validates_presence_of+ or simply +:presence+.
+    has_value :whitelist_type, :default => nil
+
+    ##
     # :attr_accessor: except_type
     #
     # List of validation types to exclude from automatic validation.

--- a/lib/schema_validations.rb
+++ b/lib/schema_validations.rb
@@ -36,11 +36,11 @@ module SchemaValidations
     has_value :only, :default => nil
 
     ##
-    # :attr_accessor: except
+    # :attr_accessor: whitelist
     #
     # List of field names to exclude from automatic validation.
     # Value is a single name, an array of names, or +nil+.  Default is <tt>[:created_at, :updated_at, :created_on, :updated_on]</tt>.
-    has_value :except, :default => [:created_at, :updated_at, :created_on, :updated_on]
+    has_value :whitelist, :default => [:created_at, :updated_at, :created_on, :updated_on]
 
     ##
     # :attr_accessor: except_type

--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -52,8 +52,10 @@ module SchemaValidations
       #     end
       #
       #
-      def schema_validations(opts={})
-        @schema_validations_config = SchemaValidations.config.merge({:auto_create => true}.merge(opts))
+      def schema_validations(options={})
+        except = options.delete(:except)
+        @schema_validations_config = SchemaValidations.config.merge({:auto_create => true}.merge(options))
+        @schema_validations_config.except += [except].flatten if except
       end
 
       def schema_validations_config # :nodoc:

--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -55,7 +55,7 @@ module SchemaValidations
       def schema_validations(options={})
         except = options.delete(:except)
         @schema_validations_config = SchemaValidations.config.merge({:auto_create => true}.merge(options))
-        @schema_validations_config.except += [except].flatten if except
+        @schema_validations_config.whitelist += Array(except) if except
       end
 
       def schema_validations_config # :nodoc:
@@ -204,7 +204,7 @@ module SchemaValidations
           types << match[1].to_sym
         end
         return false if config.only        and not Array.wrap(config.only).include?(name)
-        return false if config.except      and     Array.wrap(config.except).include?(name)
+        return false if config.whitelist      and     Array.wrap(config.whitelist).include?(name)
         return false if config.only_type   and not (Array.wrap(config.only_type) & types).any?
         return false if config.except_type and     (Array.wrap(config.except_type) & types).any?
         return true

--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -201,10 +201,12 @@ module SchemaValidations
         if match = macro.to_s.match(/^validates_(.*)_of$/)
           types << match[1].to_sym
         end
-        return false if config.only        and not Array.wrap(config.only).include?(name)
+        return false if config.only           and not Array.wrap(config.only).include?(name)
+        return false if config.except         and     Array.wrap(config.except).include?(name)
         return false if config.whitelist      and     Array.wrap(config.whitelist).include?(name)
-        return false if config.only_type   and not (Array.wrap(config.only_type) & types).any?
-        return false if config.except_type and     (Array.wrap(config.except_type) & types).any?
+        return false if config.only_type      and not (Array.wrap(config.only_type) & types).any?
+        return false if config.except_type    and     (Array.wrap(config.except_type) & types).any?
+        return false if config.whitelist_type and     (Array.wrap(config.whitelist_type) & types).any?
         return true
       end
 

--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -52,10 +52,8 @@ module SchemaValidations
       #     end
       #
       #
-      def schema_validations(options={})
-        except = options.delete(:except)
-        @schema_validations_config = SchemaValidations.config.merge({:auto_create => true}.merge(options))
-        @schema_validations_config.whitelist += Array(except) if except
+      def schema_validations(opts={})
+        @schema_validations_config = SchemaValidations.config.merge({:auto_create => true}.merge(opts))
       end
 
       def schema_validations_config # :nodoc:

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -21,6 +21,7 @@ describe "Validations" do
         t.string :author, :null => false
         t.string :content, :limit => 200
         t.string :type
+        t.timestamps :null => false
       end
       add_index :reviews, :article_id, :unique => true
 

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -176,6 +176,18 @@ describe "Validations" do
       expect(@review.error_on(:author).size).to eq(1)
     end
 
+    it "shouldn't validate the fields in default whitelist" do
+      Review.schema_validations :except => :content
+      expect(Review.new.error_on(:updated_at).size).to eq(0)
+      expect(Review.new.error_on(:created_at).size).to eq(0)
+    end
+
+    it "shouldn't validate the fields in whitelist" do
+      Review.schema_validations :except => :content, whitelist: [:updated_at]
+      expect(Review.new.error_on(:updated_at).size).to eq(0)
+      expect(Review.new.error_on(:created_at).size).to eq(1)
+    end
+
     it "shouldn't validate types passed to :except_type option using full validation" do
       Review.schema_validations :except_type => :validates_length_of
       @review = Review.new(:content => @too_big_content)


### PR DESCRIPTION
```
class Article  < ActiveRecord::Base
  schema_validations except: [:name]
end
```

When I specify an except option in my mode, I get the error: `ActiveRecord::RecordInvalid: Validation failed: Created at can't be blank, Updated at can't be blank` when I trying to save the model.

It is because that the default `except` hash is replaced by the custom options, which I think doesn't make sense. The attributes like `updated/created_at` should always be whitelisted. 