### PR TITLE
Validate decimal range

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Data types:
 | `:boolean`         | `:validates ... inclusion: { in: [true, false] }`                                                    |
 | `:float`           | `:validates ... numericality: true`                                                                  |
 | `:integer`         | `:validates ... numericality: { only_integer: true, greater_than_or_equal_to: ..., less_than: ... }` |
+| `:decimal`         | `:validates ... numericality: { greater_than: ..., less_than: ... }`                                 |
 
 
 ## What if I want something special?

--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -98,6 +98,7 @@ module SchemaValidations
             datatype = case
                        when respond_to?(:defined_enums) && defined_enums.has_key?(column.name) then :enum
                        when column.type == :integer then :integer
+                       when column.type == :decimal then :decimal
                        when column.number? then :numeric
                        when column.text? then :text
                        when column.type == :boolean then :boolean
@@ -106,6 +107,9 @@ module SchemaValidations
             case datatype
             when :integer
               load_integer_column_validations(name, column)
+            when :decimal
+              limit = 10 ** (column.precision - column.scale)
+              validate_logged :validates_numericality_of, name, :allow_nil => true, :greater_than => -limit, :less_than => limit
             when :numeric
               validate_logged :validates_numericality_of, name, :allow_nil => true
             when :text

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -12,6 +12,7 @@ describe "Validations" do
         t.integer :votes
         t.float   :average_mark, :null => false
         t.boolean :active, :null => false
+        t.decimal :rating, :precision => 2, :scale => 1
       end
       add_index :articles, :title, :unique => true
       add_index :articles, [:state, :active], :unique => true
@@ -92,6 +93,11 @@ describe "Validations" do
     it "should validate the range of votes" do
       expect(Article.new(votes: 2147483648).error_on(:votes).size).to eq(1)
       expect(Article.new(votes: -2147483649).error_on(:votes).size).to eq(1)
+    end
+
+    it "should validate the range of rating" do
+      expect(Article.new(rating: 10).error_on(:rating).size).to eq(1)
+      expect(Article.new(rating: -10).error_on(:rating).size).to eq(1)
     end
 
     it "should validate average_mark numericality" do


### PR DESCRIPTION
The range of decimal columns is limited by the number of numerals (precision) and decimals (scale).

**Example:**

The range for a decimal column with precision 4 and scale 2 is ±99.99
or < 10^2 and > -10^2 using the formula abs(10^(precision - scale)).

This resolves #35.