### PR TITLE
Support case-insensitive uniqueness validations under MySQL

### DIFF
--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -182,7 +182,7 @@ module SchemaValidations
         end
 
         def column_is_case_insensitive?(column)
-          column.respond_to?(:case_sensitive?) && ! column.case_sensitive?
+          column.respond_to?(:collation) && column.respond_to?(:case_sensitive?) && ! column.case_sensitive?
         end
 
         def has_case_insensitive_index?(column, scope)

--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -169,7 +169,7 @@ module SchemaValidations
           options = {}
           options[:scope] = scope if scope.any?
           options[:allow_nil] = true
-          options[:case_sensitive] = false if has_case_insensitive_index?(column, scope)
+          options[:case_sensitive] = false if column_is_case_insensitive?(column) or has_case_insensitive_index?(column, scope)
           options[:if] = (proc do |record|
             if scope.all? { |scope_sym| record.public_send(:"#{scope_sym}?") }
               record.public_send(:"#{column.name}_changed?")
@@ -179,6 +179,10 @@ module SchemaValidations
           end)
 
           validate_logged :validates_uniqueness_of, name, options
+        end
+
+        def column_is_case_insensitive?(column)
+          column.respond_to?(:case_sensitive?) && ! column.case_sensitive?
         end
 
         def has_case_insensitive_index?(column, scope)


### PR DESCRIPTION
This is a proposed fix for issue #38 

I'm not sure how to proceed writing a test spec for this.  It should only be run with against a MySQL database, and furthermore may require creating a table using raw SQL (execute) rather than as a rails schema migration/load; because a proper test will rely on the MySQL ```COLLATION``` type qualifier which is not exposed by the schema loader/dumper (though it is a read-only property of the Column type).

The example code presented in the issue would probably serve as a good basis for a test.