### PR TITLE
Make the gem work if ActiveRecord logger is nil

### DIFF
--- a/lib/schema_validations/active_record/validations.rb
+++ b/lib/schema_validations/active_record/validations.rb
@@ -196,7 +196,7 @@ module SchemaValidations
           if _filter_validation(method, arg)
             msg = "[schema_validations] #{self.name}.#{method} #{arg.inspect}"
             msg += ", #{opts.inspect[1...-1]}" if opts.any?
-            logger.debug msg
+            logger.debug msg if logger
             send method, arg, opts
           end
         end


### PR DESCRIPTION
I don't know exactly why but in our environment (under delayed job) the logger is nil at the moment of this debug call. 